### PR TITLE
ex0/server.c: fix clientlen type

### DIFF
--- a/ex0/server.c
+++ b/ex0/server.c
@@ -57,7 +57,8 @@ int main(int argc,  char *argv[])
 	struct sockaddr_in sockname, client;
 	char buffer[80], *ep;
 	struct sigaction sa;
-	int clientlen, sd;
+	unsigned int clientlen;
+	int sd;
 	u_short port;
 	pid_t pid;
 	u_long p;


### PR DESCRIPTION
Fixes compilation error:
```
cc -O2 -pipe -Wall -Werror  server.c  -o server
server.c:137:53: error: passing 'int *' to parameter of type 'socklen_t *' (aka 'unsigned int *') converts between
      pointers to integer types with different sign [-Werror,-Wpointer-sign]
                      clientsd = accept(sd, (struct sockaddr *)&client, &clientlen);
```