### PR TITLE
Fixes to makecert.sh

### DIFF
--- a/CA/makecert.sh
+++ b/CA/makecert.sh
@@ -46,13 +46,13 @@ else
     subject="/emailAddress=${email}/C=CA/ST=Edmonton/O=Bob Beck/OU=Certificanator/CN=${CN}"
 fi
 
-if [ -z "$cflag"]; then
+if [ -z "$cflag" ]; then
     type="server_cert"
 else
-    type="user_cert"
+    type="usr_cert"
 fi
 
-if [ -z "$days"]; then
+if [ -z "$days" ]; then
     days="375"
 fi
 

--- a/CA/makecert.sh
+++ b/CA/makecert.sh
@@ -57,11 +57,11 @@ if [ -z "$days" ]; then
 fi
 
 keyfile="${CN}.key"
-csrfile="${CN},csr"
+csrfile="${CN}.pem"
 crtfile="${CN}.crt"
 
 (cd intermediate && openssl genrsa -out private/${keyfile} 2048)
-(cd intermediate && openssl req -batch -config openssl.cnf -new -key private/client.key -subj "${subject}" -out csr/$csrfile)
+(cd intermediate && openssl req -batch -config openssl.cnf -new -key private/${keyfile} -subj "${subject}" -out csr/${csrfile})
 openssl ca -batch -config intermediate/openssl.cnf -extensions ${type} -days ${days} -notext -md sha256 -in intermediate/csr/${csrfile} -out intermediate/certs/${crtfile}
 if [ $? -eq 0 ]; then
     cp intermediate/private/${keyfile} ${keyfile}


### PR DESCRIPTION
Fixes to `makecert.sh`:

- Insert a space before `test`'s close bracket.
- Extensions for client certificates are in `usr_cert` section.
